### PR TITLE
Add save state & resume edit feature.

### DIFF
--- a/sample/src/main/java/com/yalantis/ucrop/sample/ResultActivity.java
+++ b/sample/src/main/java/com/yalantis/ucrop/sample/ResultActivity.java
@@ -47,6 +47,9 @@ public class ResultActivity extends BaseActivity {
     private static final String CHANNEL_ID = "3000";
     private static final int DOWNLOAD_NOTIFICATION_ID_DONE = 911;
 
+    public static final String EXTRA_IS_LOCAL_IMAGE = "extra_is_local_image";
+    private boolean isLocalImage;
+
     public static void startWithUri(@NonNull Context context, @NonNull Uri uri) {
         Intent intent = new Intent(context, ResultActivity.class);
         intent.setData(uri);
@@ -74,6 +77,8 @@ public class ResultActivity extends BaseActivity {
         options.inJustDecodeBounds = true;
         BitmapFactory.decodeFile(new File(getIntent().getData().getPath()).getAbsolutePath(), options);
 
+        isLocalImage = getIntent().getBooleanExtra(EXTRA_IS_LOCAL_IMAGE, false);
+
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -85,6 +90,8 @@ public class ResultActivity extends BaseActivity {
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         getMenuInflater().inflate(R.menu.menu_result, menu);
+        // azri92 - only show edit button if source image is from local
+        menu.findItem(R.id.menu_edit).setVisible(isLocalImage);
         return true;
     }
 
@@ -92,12 +99,14 @@ public class ResultActivity extends BaseActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_download) {
             saveCroppedImage();
+        } else if (item.getItemId() == R.id.menu_edit) {
+            setResult(SampleActivity.RESULT_EDIT);
+            finish();
         } else if (item.getItemId() == android.R.id.home) {
             onBackPressed();
         }
         return super.onOptionsItemSelected(item);
     }
-
 
     /**
      * Callback received when a permissions request has been completed.

--- a/sample/src/main/java/com/yalantis/ucrop/sample/SavedImageState.java
+++ b/sample/src/main/java/com/yalantis/ucrop/sample/SavedImageState.java
@@ -1,0 +1,57 @@
+package com.yalantis.ucrop.sample;
+
+import android.graphics.RectF;
+
+import com.yalantis.ucrop.UCrop;
+
+/**
+ * @author azri92
+ * Model class to demonstrate how the saved image state could be stored and reused.
+ */
+public class SavedImageState {
+
+    private String originalPath;
+    private String destinationPath;
+    private float[] imageMatrixValues; // 9 values of matrix
+    private RectF cropRect;
+    private UCrop ucropConfig;
+
+    public SavedImageState() {}
+
+    public SavedImageState(String originalPath, String destinationPath) {
+        this.originalPath = originalPath;
+        this.destinationPath = destinationPath;
+    }
+
+    public void setImageMatrixValues(float[] imageMatrixValues) {
+        this.imageMatrixValues = imageMatrixValues;
+    }
+
+    public void setCropRect(RectF cropRect) {
+        this.cropRect = cropRect;
+    }
+
+    public void setUcropConfig(UCrop ucropConfig) {
+        this.ucropConfig = ucropConfig;
+    }
+
+    public String getOriginalPath() {
+        return originalPath;
+    }
+
+    public String getDestinationPath() {
+        return destinationPath;
+    }
+
+    public float[] getImageMatrixValues() {
+        return imageMatrixValues;
+    }
+
+    public RectF getCropRect() {
+        return cropRect;
+    }
+
+    public UCrop getUcropConfig() {
+        return ucropConfig;
+    }
+}

--- a/sample/src/main/res/drawable/ic_edit.xml
+++ b/sample/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/sample/src/main/res/menu/menu_result.xml
+++ b/sample/src/main/res/menu/menu_result.xml
@@ -2,8 +2,13 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <item android:id="@+id/menu_edit"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/ic_edit"
+        android:title="@string/menu_edit" />
+
     <item android:id="@+id/menu_download"
-          app:showAsAction="always"
+          app:showAsAction="ifRoom"
           android:icon="@drawable/ic_file_download"
           android:title="@string/menu_download"/>
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -23,13 +23,14 @@
     <string name="notification_image_saved_click_to_preview">Image saved. Click to preview.</string>
 
     <string name="menu_download">Download</string>
+    <string name="menu_edit">Edit</string>
 
     <string name="button_pick_amp_crop"><![CDATA[Pick & Crop]]></string>
     <string name="button_crop_random_image">Crop random image</string>
 
     <string name="description_cropped_image">Cropped image</string>
 
-    <string name="format_crop_result_d_d">Crop Result (%1$dx%2$d)</string>
+    <string name="format_crop_result_d_d">Result (%1$dx%2$d)</string>
     <string name="format_quality_d">Quality: %d</string>
     <string name="format_d_d_px">%1$dx%2$d px</string>
     <string name="format_max_cropped_image_size">Max cropped image size cannot be less then %d</string>

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCrop.java
@@ -6,6 +6,7 @@ import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.graphics.RectF;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -43,6 +44,8 @@ public class UCrop {
     public static final String EXTRA_OUTPUT_IMAGE_HEIGHT = EXTRA_PREFIX + ".ImageHeight";
     public static final String EXTRA_OUTPUT_OFFSET_X = EXTRA_PREFIX + ".OffsetX";
     public static final String EXTRA_OUTPUT_OFFSET_Y = EXTRA_PREFIX + ".OffsetY";
+    public static final String EXTRA_IMAGE_MATRIX_VALUES = EXTRA_PREFIX + ".ImageMatrixValues";
+    public static final String EXTRA_CROP_RECT = EXTRA_PREFIX + ".CropRect";
     public static final String EXTRA_ERROR = EXTRA_PREFIX + ".Error";
 
     public static final String EXTRA_ASPECT_RATIO_X = EXTRA_PREFIX + ".AspectRatioX";
@@ -69,6 +72,17 @@ public class UCrop {
         mCropOptionsBundle = new Bundle();
         mCropOptionsBundle.putParcelable(EXTRA_INPUT_URI, source);
         mCropOptionsBundle.putParcelable(EXTRA_OUTPUT_URI, destination);
+    }
+
+    /**
+     * @author azri92
+     * @param imageMatrixValues values of previous image matrix before crop.
+     * @param cropRect of previous edit.
+     */
+    public UCrop withSavedState(@NonNull float[] imageMatrixValues, @NonNull RectF cropRect) {
+        mCropOptionsBundle.putFloatArray(EXTRA_IMAGE_MATRIX_VALUES, imageMatrixValues);
+        mCropOptionsBundle.putParcelable(EXTRA_CROP_RECT, cropRect);
+        return this;
     }
 
     /**

--- a/ucrop/src/main/java/com/yalantis/ucrop/UCropFragment.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/UCropFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.PorterDuff;
+import android.graphics.RectF;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.ColorInt;
@@ -158,6 +159,8 @@ public class UCropFragment extends Fragment {
         Uri inputUri = bundle.getParcelable(UCrop.EXTRA_INPUT_URI);
         Uri outputUri = bundle.getParcelable(UCrop.EXTRA_OUTPUT_URI);
         processOptions(bundle);
+
+        // TODO: Add resume edit feature into Fragment
 
         if (inputUri != null && outputUri != null) {
             try {
@@ -500,8 +503,25 @@ public class UCropFragment extends Fragment {
         mGestureCropImageView.cropAndSaveImage(mCompressFormat, mCompressQuality, new BitmapCropCallback() {
 
             @Override
-            public void onBitmapCropped(@NonNull Uri resultUri, int offsetX, int offsetY, int imageWidth, int imageHeight) {
-                callback.onCropFinish(getResult(resultUri, mGestureCropImageView.getTargetAspectRatio(), offsetX, offsetY, imageWidth, imageHeight));
+            public void onBitmapCropped(
+                    @NonNull Uri resultUri,
+                    int offsetX,
+                    int offsetY,
+                    int imageWidth,
+                    int imageHeight,
+                    float[] imageMatrixValues,
+                    RectF cropRect
+            ) {
+                callback.onCropFinish(
+                        getResult(resultUri,
+                                mGestureCropImageView.getTargetAspectRatio(),
+                                offsetX,
+                                offsetY,
+                                imageWidth,
+                                imageHeight,
+                                imageMatrixValues,
+                                cropRect)
+                );
                 callback.loadingProgress(false);
             }
 
@@ -512,7 +532,16 @@ public class UCropFragment extends Fragment {
         });
     }
 
-    protected UCropResult getResult(Uri uri, float resultAspectRatio, int offsetX, int offsetY, int imageWidth, int imageHeight) {
+    protected UCropResult getResult(
+            Uri uri,
+            float resultAspectRatio,
+            int offsetX,
+            int offsetY,
+            int imageWidth,
+            int imageHeight,
+            float[] imageMatrixValues,
+            RectF cropRect
+    ) {
         return new UCropResult(RESULT_OK, new Intent()
                 .putExtra(UCrop.EXTRA_OUTPUT_URI, uri)
                 .putExtra(UCrop.EXTRA_OUTPUT_CROP_ASPECT_RATIO, resultAspectRatio)
@@ -520,6 +549,8 @@ public class UCropFragment extends Fragment {
                 .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_HEIGHT, imageHeight)
                 .putExtra(UCrop.EXTRA_OUTPUT_OFFSET_X, offsetX)
                 .putExtra(UCrop.EXTRA_OUTPUT_OFFSET_Y, offsetY)
+                .putExtra(UCrop.EXTRA_IMAGE_MATRIX_VALUES, imageMatrixValues)
+                .putExtra(UCrop.EXTRA_CROP_RECT, cropRect)
         );
     }
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/callback/BitmapCropCallback.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/callback/BitmapCropCallback.java
@@ -1,11 +1,19 @@
 package com.yalantis.ucrop.callback;
 
+import android.graphics.RectF;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
 public interface BitmapCropCallback {
 
-    void onBitmapCropped(@NonNull Uri resultUri, int offsetX, int offsetY, int imageWidth, int imageHeight);
+    void onBitmapCropped(
+            @NonNull Uri resultUri,
+            int offsetX,
+            int offsetY,
+            int imageWidth,
+            int imageHeight,
+            float[] imageMatrixValues,
+            RectF cropRect);
 
     void onCropFailure(@NonNull Throwable t);
 

--- a/ucrop/src/main/java/com/yalantis/ucrop/model/ImageState.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/model/ImageState.java
@@ -1,5 +1,6 @@
 package com.yalantis.ucrop.model;
 
+import android.graphics.Matrix;
 import android.graphics.RectF;
 
 /**
@@ -9,12 +10,20 @@ public class ImageState {
 
     private RectF mCropRect;
     private RectF mCurrentImageRect;
+    private Matrix mCurrentImageMatrix;
 
     private float mCurrentScale, mCurrentAngle;
 
-    public ImageState(RectF cropRect, RectF currentImageRect, float currentScale, float currentAngle) {
+    public ImageState(
+            RectF cropRect,
+            RectF currentImageRect,
+            Matrix currentImageMatrix,
+            float currentScale,
+            float currentAngle
+    ) {
         mCropRect = cropRect;
         mCurrentImageRect = currentImageRect;
+        mCurrentImageMatrix = currentImageMatrix;
         mCurrentScale = currentScale;
         mCurrentAngle = currentAngle;
     }
@@ -25,6 +34,10 @@ public class ImageState {
 
     public RectF getCurrentImageRect() {
         return mCurrentImageRect;
+    }
+
+    public Matrix getCurrentImageMatrix() {
+        return mCurrentImageMatrix;
     }
 
     public float getCurrentScale() {

--- a/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/task/BitmapCropTask.java
@@ -52,8 +52,14 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
     private int mCroppedImageWidth, mCroppedImageHeight;
     private int cropOffsetX, cropOffsetY;
 
-    public BitmapCropTask(@Nullable Bitmap viewBitmap, @NonNull ImageState imageState, @NonNull CropParameters cropParameters,
-                          @Nullable BitmapCropCallback cropCallback) {
+    private float[] imageMatrixValues;
+
+    public BitmapCropTask(
+            @Nullable Bitmap viewBitmap,
+            @NonNull ImageState imageState,
+            @NonNull CropParameters cropParameters,
+            @Nullable BitmapCropCallback cropCallback
+    ) {
 
         mViewBitmap = viewBitmap;
         mCropRect = imageState.getCropRect();
@@ -70,6 +76,10 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
         mImageInputPath = cropParameters.getImageInputPath();
         mImageOutputPath = cropParameters.getImageOutputPath();
         mExifInfo = cropParameters.getExifInfo();
+
+        // azri92 - Get image matrix & crop rect values to be included in result
+        imageMatrixValues = new float[9];
+        imageState.getCurrentImageMatrix().getValues(imageMatrixValues);
 
         mCropCallback = cropCallback;
     }
@@ -185,7 +195,14 @@ public class BitmapCropTask extends AsyncTask<Void, Void, Throwable> {
         if (mCropCallback != null) {
             if (t == null) {
                 Uri uri = Uri.fromFile(new File(mImageOutputPath));
-                mCropCallback.onBitmapCropped(uri, cropOffsetX, cropOffsetY, mCroppedImageWidth, mCroppedImageHeight);
+                mCropCallback.onBitmapCropped(
+                        uri,
+                        cropOffsetX,
+                        cropOffsetY,
+                        mCroppedImageWidth,
+                        mCroppedImageHeight,
+                        imageMatrixValues,
+                        mCropRect);
             } else {
                 mCropCallback.onCropFailure(t);
             }

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/OverlayView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/OverlayView.java
@@ -60,6 +60,7 @@ public class OverlayView extends View {
     private Paint mCropGridPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private Paint mCropFramePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private Paint mCropFrameCornersPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private RectF mSavedCropRect;
     @FreestyleMode
     private int mFreestyleCropMode = DEFAULT_FREESTYLE_CROP_MODE;
     private float mPreviousTouchX = -1, mPreviousTouchY = -1;
@@ -97,6 +98,16 @@ public class OverlayView extends View {
 
     public void setOverlayViewChangeListener(OverlayViewChangeListener callback) {
         mCallback = callback;
+    }
+
+    /**
+     * @author azri92
+     * For resuming previous state.
+     *
+     * @param savedCropRect of previous edit
+     */
+    public void setSavedCropRect(RectF savedCropRect) {
+        mSavedCropRect = savedCropRect;
     }
 
     @NonNull
@@ -233,7 +244,13 @@ public class OverlayView extends View {
      */
     public void setupCropBounds() {
         int height = (int) (mThisWidth / mTargetAspectRatio);
-        if (height > mThisHeight) {
+        if (mSavedCropRect != null && mCropViewRect.isEmpty()) {
+            mCropViewRect.set(
+                    getPaddingLeft() + mSavedCropRect.left,
+                    getPaddingTop() + mSavedCropRect.top,
+                    getPaddingLeft() + mSavedCropRect.right,
+                    getPaddingTop() + mSavedCropRect.bottom);
+        } else if (height > mThisHeight) {
             int width = (int) (mThisHeight * mTargetAspectRatio);
             int halfDiff = (mThisWidth - width) / 2;
             mCropViewRect.set(getPaddingLeft() + halfDiff, getPaddingTop(),

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/TransformImageView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/TransformImageView.java
@@ -45,6 +45,11 @@ public class TransformImageView extends ImageView {
 
     private float[] mInitialImageCorners;
     private float[] mInitialImageCenter;
+    private float[] mSavedImageMatrixValues;
+
+    private RectF mSavedCropRect;
+
+    private boolean mSavedStateExists = false;
 
     protected boolean mBitmapDecoded = false;
     protected boolean mBitmapLaidOut = false;
@@ -127,6 +132,40 @@ public class TransformImageView extends ImageView {
 
     public ExifInfo getExifInfo() {
         return mExifInfo;
+    }
+
+    /**
+     * @author azri92
+     * @param savedImageMatrixValues values for image {@link Matrix} from previous edit.
+     */
+    public void setSavedState(float[] savedImageMatrixValues, RectF cropRectValues) {
+        mSavedStateExists = true;
+        mSavedImageMatrixValues = savedImageMatrixValues;
+        mSavedCropRect = cropRectValues;
+    }
+
+    /**
+     * @author azri92
+     * @return true if data of last saved image exists.
+     */
+    public boolean savedImageStateExists() {
+        return mSavedStateExists;
+    }
+
+    /**
+     * @author azri92
+     * @return values for image {@link Matrix} from previous edit.
+     */
+    public float[] getSavedImageMatrixValues() {
+        return mSavedImageMatrixValues;
+    }
+
+    /**
+     * @author azri92
+     * @return crop rect from previous edit.
+     */
+    public RectF getSavedCropRect() {
+        return mSavedCropRect;
     }
 
     /**

--- a/ucrop/src/main/java/com/yalantis/ucrop/view/UCropView.java
+++ b/ucrop/src/main/java/com/yalantis/ucrop/view/UCropView.java
@@ -68,6 +68,14 @@ public class UCropView extends FrameLayout {
     }
 
     /**
+     * @author azri92
+     * @param savedCropRect from previous edit.
+     */
+    public void setSavedState(RectF savedCropRect) {
+        mViewOverlay.setSavedCropRect(savedCropRect);
+    }
+
+    /**
      * Method for reset state for UCropImageView such as rotation, scale, translation.
      * Be careful: this method recreate UCropImageView instance and reattach it to layout.
      */


### PR DESCRIPTION
- Add imageMatrix & cropRect in returned result intent & a sample of how to save the data in a model.
- Add ability for uCrop intent builder to accept imageMatrix & cropRect.
- Add setup when starting crop with saved state.
- Add edit button for local image in Result activity.
- Shorten Crop Result title string to just Result to reduce likelihood of resolution text becoming ellipses.
- Add TODO for handling in Fragment & default aspect ratio setting when resuming edit for dynamic mode.